### PR TITLE
feat(seo): include mixes content in sitemap

### DIFF
--- a/src/nuxt.config.ts
+++ b/src/nuxt.config.ts
@@ -94,6 +94,13 @@ export default defineNuxtConfig(
         },
         twitter: '@dargmuesli',
       },
+      sitemap: {
+        // Mixes come from S3, not Nuxt pages, and change independently of
+        // deploys, so they're resolved by this source at runtime rather
+        // than baked in at build time (which `zeroRuntime` would require).
+        sources: ['/api/__sitemap__/mixes'],
+        zeroRuntime: false,
+      },
 
       $production: {
         security: {

--- a/src/server/api/__sitemap__/mixes.get.ts
+++ b/src/server/api/__sitemap__/mixes.get.ts
@@ -1,0 +1,95 @@
+import { ListObjectsV2Command } from '@aws-sdk/client-s3'
+import type { SitemapUrl } from '#sitemap/types'
+
+import {
+  getCollectionPath,
+  getTrackPath,
+} from '../../../app/utils/player-route'
+
+const toSitemapUrl = (loc: string): SitemapUrl => ({
+  loc,
+  _encoded: true,
+  _i18nTransform: true,
+})
+
+const listPlaylistLevel = async ({
+  bucket,
+  playlistPath,
+}: {
+  bucket: string
+  playlistPath: string | undefined
+}) => {
+  const { client: s3 } = useS3()
+  const prefix = PLAYER_PREFIX + (playlistPath ? `${playlistPath}/` : '')
+  const collectionPaths: string[] = []
+  const trackNames: string[] = []
+  let continuationToken: string | undefined
+
+  do {
+    const data = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        ContinuationToken: continuationToken,
+        Delimiter: '/',
+        Prefix: prefix,
+      }),
+    )
+
+    for (const commonPrefix of data.CommonPrefixes ?? []) {
+      const key = commonPrefix.Prefix
+
+      if (!key) continue
+
+      collectionPaths.push(key.slice(PLAYER_PREFIX.length, -1))
+    }
+
+    for (const content of data.Contents ?? []) {
+      const key = content.Key
+
+      if (!key) continue
+
+      const match = key.slice(prefix.length).match(/^(.+)\.mp3$/)
+
+      if (match?.[1]) trackNames.push(match[1])
+    }
+
+    continuationToken = data.NextContinuationToken
+  } while (continuationToken)
+
+  return { collectionPaths, trackNames }
+}
+
+const fetchMixSitemapUrls = async (): Promise<SitemapUrl[]> => {
+  const bucket = useRuntimeConfig().public.creal.s3.bucket
+  const urls = [toSitemapUrl(getCollectionPath())]
+  const playlistPathQueue: (string | undefined)[] = [undefined]
+
+  while (playlistPathQueue.length) {
+    const playlistPath = playlistPathQueue.shift()
+    const { collectionPaths, trackNames } = await listPlaylistLevel({
+      bucket,
+      playlistPath,
+    })
+
+    for (const collectionPath of collectionPaths) {
+      urls.push(toSitemapUrl(getCollectionPath(collectionPath)))
+      playlistPathQueue.push(collectionPath)
+    }
+
+    for (const trackName of trackNames) {
+      urls.push(toSitemapUrl(getTrackPath(playlistPath, trackName)))
+    }
+  }
+
+  return urls
+}
+
+// The S3 bucket is crawled recursively (one request per collection level),
+// so this is cached independently of and longer than the sitemap module's
+// own `cacheMaxAgeSeconds`. Mixes are added infrequently, and this avoids
+// re-crawling the whole tree every time the sitemap cache itself expires.
+export default defineCachedEventHandler(fetchMixSitemapUrls, {
+  getKey: () => 'urls',
+  maxAge: 60 * 60,
+  name: 'sitemap-mixes',
+})

--- a/src/server/api/__sitemap__/mixes.get.ts
+++ b/src/server/api/__sitemap__/mixes.get.ts
@@ -64,8 +64,8 @@ const fetchMixSitemapUrls = async (): Promise<SitemapUrl[]> => {
   const urls = [toSitemapUrl(getCollectionPath())]
   const playlistPathQueue: (string | undefined)[] = [undefined]
 
-  while (playlistPathQueue.length) {
-    const playlistPath = playlistPathQueue.shift()
+  for (let i = 0; i < playlistPathQueue.length; i++) {
+    const playlistPath = playlistPathQueue[i]
     const { collectionPaths, trackNames } = await listPlaylistLevel({
       bucket,
       playlistPath,


### PR DESCRIPTION
## Summary
- Add a `sitemap.sources` server route (`server/api/__sitemap__/mixes.get.ts`) that recursively crawls the S3 player bucket and emits a sitemap URL for every mix collection and track, reusing the app's own `getCollectionPath`/`getTrackPath` encoders so entries match the real routes exactly.
- Wire it into `nuxt.config.ts` via `sitemap.sources`, opting this app out of the base layer's `zeroRuntime` (build-time-only) mode, since mixes live in S3 and change independently of deploys.
- Cache the endpoint for an hour (`defineCachedEventHandler`) independently of `@nuxtjs/sitemap`'s own cache, to avoid re-crawling S3 on every sitemap refresh.

Closes #317