### PR TITLE
feat(pagination): use strapi page-based pagination and vueuse route query

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,9 @@ importers:
       '@vuelidate/validators':
         specifier: 2.0.4
         version: 2.0.4(vue@3.5.40(typescript@6.0.3))
+      '@vueuse/router':
+        specifier: 14.4.0
+        version: 14.4.0(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.0)(rollup@4.62.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))(vue@3.5.40(typescript@6.0.3))
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -4265,8 +4268,19 @@ packages:
   '@vueuse/metadata@14.3.0':
     resolution: {integrity: sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==}
 
+  '@vueuse/router@14.4.0':
+    resolution: {integrity: sha512-q+dRUKI6xYGT4vNPq2t3fujrXPw2KBFV5Jxhw38liTFzwzGXBYcf8Qdjk7AiQpjEH2xLSin6WVTvj85EEIpo9w==}
+    peerDependencies:
+      vue: ^3.5.0
+      vue-router: ^4.0.0 || ^5.0.0
+
   '@vueuse/shared@14.3.0':
     resolution: {integrity: sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  '@vueuse/shared@14.4.0':
+    resolution: {integrity: sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g==}
     peerDependencies:
       vue: ^3.5.0
 
@@ -13820,7 +13834,17 @@ snapshots:
 
   '@vueuse/metadata@14.3.0': {}
 
+  '@vueuse/router@14.4.0(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.0)(rollup@4.62.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))(vue@3.5.40(typescript@6.0.3))':
+    dependencies:
+      '@vueuse/shared': 14.4.0(vue@3.5.40(typescript@6.0.3))
+      vue: 3.5.40(typescript@6.0.3)
+      vue-router: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.0)(rollup@4.62.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23))
+
   '@vueuse/shared@14.3.0(vue@3.5.40(typescript@6.0.3))':
+    dependencies:
+      vue: 3.5.40(typescript@6.0.3)
+
+  '@vueuse/shared@14.4.0(vue@3.5.40(typescript@6.0.3))':
     dependencies:
       vue: 3.5.40(typescript@6.0.3)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,8 @@ minimumReleaseAgeExclude:
   - '@nuxt/schema@4.5.1'
   - '@nuxt/vite-builder@4.5.1'
   - nuxt@4.5.1
+  - '@vueuse/router@14.4.0'
+  - '@vueuse/shared@14.4.0'
 packages:
   - src
   - tests

--- a/src/app/components/cr/paging/CrPaging.vue
+++ b/src/app/components/cr/paging/CrPaging.vue
@@ -6,72 +6,54 @@
       :is-next-allowed="isNextAllowed"
       :is-previous-allowed="isPreviousAllowed"
       :part-string="partString"
-      :query-next="queryNext"
-      :query-previous="queryPrevious"
     />
   </div>
 </template>
 
 <script setup lang="ts">
-import type { LocationQuery } from '#vue-router'
-
 const {
   isPreviousAllowed = true,
   isNextAllowed = true,
+  page,
   partString,
-  queryPrevious,
-  queryNext,
 } = defineProps<{
   isPreviousAllowed?: boolean
   isNextAllowed?: boolean
+  page: number
   partString: string
-  queryPrevious: LocationQuery
-  queryNext: LocationQuery
 }>()
 
 const route = useRoute()
+const router = useRouter()
 
 // methods
-const init = () => {
-  if (queryPrevious === undefined || queryNext === undefined) return {}
+// page 1 is the default and is kept out of the URL for a clean canonical link
+const resolvePageHref = (targetPage: number) => {
+  const { page: _currentPage, ...queryRest } = route.query
 
-  const queryPreviousSearchParamsString = '?' + queryPrevious.toString()
-
-  useHead({
-    link: [
-      // // Overrides nuxtseo's canonical link, breaking Google's SEO
-      // {
-      //   href: route.path,
-      //   rel: 'canonical',
-      // },
-      ...(isPreviousAllowed
-        ? [
-            {
-              href:
-                queryPreviousSearchParamsString === '?'
-                  ? route.path
-                  : route.path + queryPreviousSearchParamsString,
-              rel: 'prev' as const,
-            },
-          ]
-        : []),
-      ...(isNextAllowed
-        ? [
-            {
-              href:
-                route.path +
-                '?' +
-                (queryNext as Record<string, string>).toString(),
-              rel: 'next' as const,
-            },
-          ]
-        : []),
-    ],
-  })
+  return router.resolve({
+    path: route.path,
+    query:
+      targetPage > 1 ? { ...queryRest, page: String(targetPage) } : queryRest,
+  }).href
 }
 
 // initialization
-init()
+useHead({
+  link: [
+    // // Overrides nuxtseo's canonical link, breaking Google's SEO
+    // {
+    //   href: route.path,
+    //   rel: 'canonical',
+    // },
+    ...(isPreviousAllowed
+      ? [{ href: resolvePageHref(page - 1), rel: 'prev' as const }]
+      : []),
+    ...(isNextAllowed
+      ? [{ href: resolvePageHref(page + 1), rel: 'next' as const }]
+      : []),
+  ],
+})
 </script>
 
 <script lang="ts">

--- a/src/app/components/cr/paging/CrPagingControls.vue
+++ b/src/app/components/cr/paging/CrPagingControls.vue
@@ -1,30 +1,40 @@
 <template>
-  <div class="text-center">
-    <div class="my-4">{{ partString }}</div>
-    <div class="inline-grid grid-cols-2">
-      <VioButton
-        :aria-label="t('previous')"
-        :disabled="!isPreviousAllowed"
-        :icon="false"
-        :wrapper-class="'mx-2'"
-        @click="goPrevious"
-      >
-        {{ t('previous') }}
-      </VioButton>
-      <VioButton
-        :aria-label="t('next')"
-        :disabled="!isNextAllowed"
-        :icon="false"
-        :wrapper-class="'mx-2'"
-        @click="goNext"
-      >
-        {{ t('next') }}
-      </VioButton>
-    </div>
-  </div>
+  <nav
+    aria-label="Pagination"
+    class="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center sm:gap-6"
+  >
+    <VioButtonColored
+      :aria-label="t('previous')"
+      class="disabled:pointer-events-none disabled:opacity-40"
+      :disabled="!isPreviousAllowed"
+      :is-primary="false"
+      @click="goPrevious"
+    >
+      <template #prefix>
+        <ChevronLeftIcon aria-hidden="true" class="h-5 w-5" />
+      </template>
+      {{ t('previous') }}
+    </VioButtonColored>
+    <span class="text-sm text-gray-500 dark:text-gray-400">
+      {{ partString }}
+    </span>
+    <VioButtonColored
+      :aria-label="t('next')"
+      class="disabled:pointer-events-none disabled:opacity-40"
+      :disabled="!isNextAllowed"
+      :is-primary="false"
+      @click="goNext"
+    >
+      {{ t('next') }}
+      <template #suffix>
+        <ChevronRightIcon aria-hidden="true" class="h-5 w-5" />
+      </template>
+    </VioButtonColored>
+  </nav>
 </template>
 
 <script setup lang="ts">
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/vue/24/outline'
 import { useRouteQuery } from '@vueuse/router'
 
 const { isPreviousAllowed = true, isNextAllowed = true } = defineProps<{

--- a/src/app/components/cr/paging/CrPagingControls.vue
+++ b/src/app/components/cr/paging/CrPagingControls.vue
@@ -25,38 +25,23 @@
 </template>
 
 <script setup lang="ts">
-import type { LocationQuery } from '#vue-router'
+import { useRouteQuery } from '@vueuse/router'
 
-const {
-  isPreviousAllowed = true,
-  isNextAllowed = true,
-  partString,
-  queryPrevious,
-  queryNext,
-} = defineProps<{
+const { isPreviousAllowed = true, isNextAllowed = true } = defineProps<{
   isPreviousAllowed?: boolean
   isNextAllowed?: boolean
   partString: string
-  queryPrevious: LocationQuery
-  queryNext: LocationQuery
 }>()
 
 const { t } = useI18n()
-const route = useRoute()
-const router = useRouter()
+const page = useRouteQuery('page', '1', {
+  mode: 'push',
+  transform: { get: Number, set: String },
+})
 
 // methods
-const goPrevious = () =>
-  router.push({
-    path: route.path,
-    query: queryPrevious,
-  })
-
-const goNext = () =>
-  router.push({
-    path: route.path,
-    query: queryNext,
-  })
+const goPrevious = () => page.value--
+const goNext = () => page.value++
 </script>
 
 <i18n lang="yaml">

--- a/src/app/composables/strapi.ts
+++ b/src/app/composables/strapi.ts
@@ -1,7 +1,22 @@
-import type { StrapiResult } from '@dargmuesli/nuxt-vio/shared/types/fetch'
+import type { CollectionItem } from '@dargmuesli/nuxt-vio/shared/types/fetch'
 import { FETCH_RETRY_AMOUNT } from '@dargmuesli/nuxt-vio/shared/utils/constants'
 import { consola } from 'consola'
 import type { FetchOptions } from 'ofetch'
+
+// Strapi's REST API only returns `pageCount` for page-based pagination
+// (`pagination[page]`/`pagination[pageSize]`), not for offset-based
+// pagination - hence this narrower result type than `StrapiResult`.
+type StrapiPageResult<T> = {
+  data: CollectionItem<T>[]
+  meta: {
+    pagination: {
+      page: number
+      pageCount: number
+      pageSize: number
+      total: number
+    }
+  }
+}
 
 export const useStrapiData = async <T>({
   path,
@@ -16,27 +31,24 @@ export const useStrapiData = async <T>({
 
   // data
   const requestError = ref()
-  const queryLimit = +(route.query.limit ? route.query.limit : 100)
-  const queryStart = +(route.query.start ? route.query.start : 0)
+  const queryPage = +(route.query.page ? route.query.page : 1)
+  const queryPageSize = +(route.query.pageSize ? route.query.pageSize : 100)
 
   try {
     // async data
-    const asyncData = await strapiFetch<StrapiResult<T>>(path, {
+    const asyncData = await strapiFetch<StrapiPageResult<T>>(path, {
       query: {
         locale: locale.value,
-        'pagination[limit]': String(queryLimit),
-        'pagination[start]': String(queryStart),
+        'pagination[page]': String(queryPage),
+        'pagination[pageSize]': String(queryPageSize),
         ...query,
       },
       retry: FETCH_RETRY_AMOUNT,
     })
     const items = asyncData.data
     const paging = getPaging({
-      items,
-      itemsCountTotal: asyncData?.meta.pagination.total,
-      query: route.query,
-      start: queryStart,
-      limit: queryLimit,
+      itemsCountOnPage: items.length,
+      pagination: asyncData.meta.pagination,
     })
 
     return { items, paging, requestError }

--- a/src/app/pages/events/index.vue
+++ b/src/app/pages/events/index.vue
@@ -11,9 +11,8 @@
       class="flex flex-col gap-16"
       :is-next-allowed="paging.isNextAllowed"
       :is-previous-allowed="paging.isPreviousAllowed"
+      :page="paging.page"
       :part-string="paging.partString"
-      :query-next="paging.queryNext"
-      :query-previous="paging.queryPrevious"
     >
       <CrEventList v-if="eventsCurrent" :events="eventsCurrent">
         <div class="flex items-center gap-2">
@@ -33,6 +32,11 @@
 </template>
 
 <script setup lang="ts">
+// remount on pagination changes so the top-level `await` below refetches
+definePageMeta({
+  key: (route) => route.fullPath,
+})
+
 const {
   items: events,
   paging,

--- a/src/app/pages/faq/index.vue
+++ b/src/app/pages/faq/index.vue
@@ -10,9 +10,8 @@
       v-if="faqs?.length && paging"
       :is-next-allowed="paging.isNextAllowed"
       :is-previous-allowed="paging.isPreviousAllowed"
+      :page="paging.page"
       :part-string="paging.partString"
-      :query-next="paging.queryNext"
-      :query-previous="paging.queryPrevious"
     >
       <ul>
         <li
@@ -43,6 +42,11 @@
 <script setup lang="ts">
 import { htmlToText } from 'html-to-text'
 import { marked } from 'marked'
+
+// remount on pagination changes so the top-level `await` below refetches
+definePageMeta({
+  key: (route) => route.fullPath,
+})
 
 const { t } = useI18n()
 const route = useRoute()
@@ -76,8 +80,6 @@ const toggleItemFocus = (id: string) => {
 onMounted(() => {
   itemFocusedId.value = route.hash.substring(1)
 })
-// watchQuery: ['limit', 'start'],
-
 // initialization
 useCrealHeadDefault({
   description: t('description'),

--- a/src/app/pages/testimonials/index.vue
+++ b/src/app/pages/testimonials/index.vue
@@ -11,9 +11,8 @@
         class="flex flex-col gap-4 lg:gap-8"
         :is-next-allowed="paging.isNextAllowed"
         :is-previous-allowed="paging.isPreviousAllowed"
+        :page="paging.page"
         :part-string="paging.partString"
-        :query-next="paging.queryNext"
-        :query-previous="paging.queryPrevious"
       >
         <ul>
           <li
@@ -48,6 +47,11 @@
 </template>
 
 <script setup lang="ts">
+// remount on pagination changes so the top-level `await` below refetches
+definePageMeta({
+  key: (route) => route.fullPath,
+})
+
 const { t } = useI18n()
 const localePath = useLocalePath()
 const { items, paging, requestError } = await useStrapiData<CrealTestimonial>({

--- a/src/app/utils/paging.ts
+++ b/src/app/utils/paging.ts
@@ -1,43 +1,28 @@
-import type { LocationQuery } from '#vue-router'
-
-export const getPaging = <T>({
-  items,
-  itemsCountTotal,
-  query,
-  start,
-  limit,
+export const getPaging = ({
+  itemsCountOnPage,
+  pagination,
 }: {
-  items?: T[]
-  itemsCountTotal?: number
-  query: LocationQuery
-  start: number
-  limit: number
+  itemsCountOnPage: number
+  pagination: {
+    page: number
+    pageCount: number
+    pageSize: number
+    total: number
+  }
 }) => {
+  const { page, pageCount, pageSize, total } = pagination
+  const start = (page - 1) * pageSize
   const partString =
-    (items?.length && items?.length > 0 ? start + 1 : 0) +
+    (itemsCountOnPage > 0 ? start + 1 : 0) +
     '-' +
-    (items?.length && items.length > 0 ? start + items.length : 0) +
+    (itemsCountOnPage > 0 ? start + itemsCountOnPage : 0) +
     ' / ' +
-    itemsCountTotal
-
-  const startPrevious = Math.max(0, start - limit)
-  const queryPrevious = {
-    ...(query.limit && { limit: query.limit }),
-    ...(startPrevious > 0 && { start: `${startPrevious}` }),
-  }
-  const queryNext = {
-    ...(query.limit && { limit: query.limit }),
-    start: `${start + limit}`,
-  }
-
-  const isNextAllowed = start + (items?.length || 0) < (itemsCountTotal || 0)
-  const isPreviousAllowed = start > 0
+    total
 
   return {
-    isNextAllowed,
-    isPreviousAllowed,
+    isNextAllowed: page < pageCount,
+    isPreviousAllowed: page > 1,
+    page,
     partString,
-    queryNext,
-    queryPrevious,
   } as Paging
 }

--- a/src/package.json
+++ b/src/package.json
@@ -26,6 +26,7 @@
     "@urql/vue": "2.1.1",
     "@vuelidate/core": "2.0.3",
     "@vuelidate/validators": "2.0.4",
+    "@vueuse/router": "14.4.0",
     "clsx": "2.1.1",
     "consola": "3.4.2",
     "defu": "6.1.7",

--- a/src/shared/types/paging.d.ts
+++ b/src/shared/types/paging.d.ts
@@ -1,9 +1,6 @@
-import type { LocationQuery } from '#vue-router'
-
 export interface Paging {
   isNextAllowed: boolean
   isPreviousAllowed: boolean
+  page: number
   partString: string
-  queryNext: LocationQuery
-  queryPrevious: LocationQuery
 }


### PR DESCRIPTION
## Summary
- Switches Strapi pagination requests from offset-based (`pagination[start]`/`pagination[limit]`) to page-based (`pagination[page]`/`pagination[pageSize]`), which returns `pageCount` directly and removes hand-rolled next/previous-availability math from `getPaging`.
- Replaces manual route-query parsing and `router.push` query-building in the pagination controls with `@vueuse/router`'s `useRouteQuery`.
- Keys the paginated pages (`events`, `faq`, `testimonials`) on the full route path so Next/Previous clicks actually refetch data instead of only updating the URL (a pre-existing bug this refactor surfaced).
- Closes #237 as not planned: `useOffsetPagination` itself doesn't fit this app's SSR/URL-driven pagination model, but the underlying goal (less reimplemented pagination plumbing) is addressed via the above.